### PR TITLE
Feat(#23): 메인페이지 헤더 구현 

### DIFF
--- a/src/components/feature/home/Header/index.tsx
+++ b/src/components/feature/home/Header/index.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 import { GiHamburgerMenu } from 'react-icons/gi';
-import { Link } from 'react-router-dom';
 
-import { RouterPath } from '@/routes/path';
 
 const MainHeader = () => {
   const handleClick = () => {
@@ -10,11 +8,7 @@ const MainHeader = () => {
   };
   return (
   <Wrapper>
-    <Left>
-        <Link to={RouterPath.home}>
-          {/* 아직 홈페이지 없는 상태라 작동X. 빌드도 오류 날 것임. */}
-          Rebit {/* 레빗로고 이미지 따서 올려야함 */}
-        </Link>
+      <Left>
       </Left>
       <Right>
         <GiHamburgerMenu size={30} color={'white'} onClick={handleClick} />
@@ -26,7 +20,7 @@ const MainHeader = () => {
 const Wrapper = styled.header`
   width: 100%;
   max-width: 100vw;
-  height: 30px;
+  height: 50px;
   display: flex;
   background-color: black;
 `;
@@ -36,6 +30,7 @@ const Left = styled.div`
 `;
 
 const Right = styled.div`
+  padding: 10px;
   margin-left: auto;
   cursor: pointer;
 `;

--- a/src/components/feature/home/header.tsx
+++ b/src/components/feature/home/header.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { GiHamburgerMenu } from 'react-icons/gi';
+import { Link } from 'react-router-dom';
+
+import { RouterPath } from '@/routes/path';
+
+const MainHeader = () => {
+  const handleClick = () => {
+    alert('사이드바 열기');
+  };
+  return (
+  <Wrapper>
+    <Left>
+        <Link to={RouterPath.home}>
+          {/* 아직 홈페이지 없는 상태라 작동X. 빌드도 오류 날 것임. */}
+          Rebit {/* 레빗로고 이미지 따서 올려야함 */}
+        </Link>
+      </Left>
+      <Right>
+        <GiHamburgerMenu size={30} color={'white'} onClick={handleClick} />
+      </Right>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.header`
+  width: 100%;
+  max-width: 100vw;
+  height: 30px;
+  display: flex;
+  background-color: black;
+`;
+
+const Left = styled.div`
+  justify-content: flex-start;
+`;
+
+const Right = styled.div`
+  margin-left: auto;
+  cursor: pointer;
+`;
+export default MainHeader;

--- a/src/components/feature/layouts/header.tsx
+++ b/src/components/feature/layouts/header.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { GiHamburgerMenu } from 'react-icons/gi';
+import { Link } from 'react-router-dom';
+
+import { RouterPath } from '@/routes/path';
+
+const Header = () => {
+  const handleClick = () => {
+    alert('사이드바 열기');
+  };
+  return (
+    <Wrapper>
+      <Left>
+        <Link to={RouterPath.home}>
+          {/* 아직 홈페이지 없는 상태라 작동X. 빌드도 오류 날 것임. */}
+          Rebit {/* 레빗로고 이미지 따서 올려야함 */}
+        </Link>
+      </Left>
+      <Right>
+        <GiHamburgerMenu size={30} color={'black'} onClick={handleClick} />
+      </Right>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.header`
+  width: 100%;
+  max-width: 100vw;
+  height: 30px;
+  display: flex;
+  background-color: fff;
+`;
+
+const Left = styled.div`
+  justify-content: flex-start;
+`;
+
+const Right = styled.div`
+  margin-left: auto;
+  cursor: pointer;
+`;
+export default Header;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
joshuayeyo: feat/23/header-component => Team15_FE: Weekly_4

### 작업 내용 및 변경 사항
- 메인페이지용 헤더 구현 
- 어차피 홈화면이라서, 홈 네비게이션 필요 없을 것 같아 사이드바만 넣어뒀음.(필요하면 추가)
- 구현하면서 좀 고민한 부분인데, 어차피 메인페이지 / 그 외 식의 헤더 구성이라, 굳이 Step2 버튼처럼 하는 것 보다는 각기다른 2개 만들어서 달아두는게 더 예쁠 것 같아서 일단 메인페이지용 헤더만 따로 만들었음.

### 테스트 결과 이미지(화면 캡쳐해서)
![スクリーンショット 0006-09-27 17 14 50](https://github.com/user-attachments/assets/ceee0ddf-05f8-4718-86eb-227a7bb9b421)

### Todo
- [ ] 공통 헤더 컴포넌트 하나 만들기
### 이슈 링크
https://github.com/kakao-tech-campus-2nd-step3/Team15_FE/issues/23

### 리뷰어 멘션하기
@eunjin210 