### PR TITLE
Feat(#61): 피드페이지(공통) 헤더 추가

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -32,7 +32,7 @@ const CommonHeader = () => {
 const Wrapper = styled.header`
     width: 100%;
     max-width: 100vw;
-    height: 3vw;
+    height: 2.5vh;
     display: flex;
 `;
 

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+import { GiHamburgerMenu } from 'react-icons/gi';
+import { useState } from 'react';
+import Sidebar from "@/components/common/Sidebar";
+import OverlayWrapper from '@/components/common/overlay';
+import { Link } from 'react-router-dom';
+import Homepage from '@/pages/Home';
+
+const CommonHeader = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const toggleSide = () =>{
+        setIsOpen(true);
+    };
+    return (
+        <Wrapper>
+            <Left>
+                <Link to="/">
+                    <Text>
+                        Rebit
+                    </Text>
+                </Link>
+            </Left>
+            <Right>
+                <GiHamburgerMenu size={'2vw'} color={'black'} onClick={toggleSide}/>
+                <Sidebar isOpen={isOpen} setIsOpen={setIsOpen} />
+                <OverlayWrapper isOpen={isOpen}/>
+            </Right>
+        </Wrapper>
+    );
+};
+
+const Wrapper = styled.header`
+    width: 100%;
+    max-width: 100vw;
+    height: 3vw;
+    display: flex;
+`;
+
+const Text = styled.text`
+    font-size: 2vw;
+    cursor: pointer;
+    font-family: 'Pretendard-Regular';
+    font-weight: 900;
+`
+
+const Left = styled.div`
+    justify-content: flex-start;
+    padding: 10px;
+`;
+
+const Right = styled.div`
+    padding: 10px;
+    margin-left: auto;
+    cursor: pointer;
+`;
+export default CommonHeader;

--- a/src/pages/Feed/index.tsx
+++ b/src/pages/Feed/index.tsx
@@ -1,10 +1,10 @@
+import CommonHeader from "@/components/common/Header";
 import Navbar from "@/components/feature/feed/Navbar"
-import MainHeader from "@/components/feature/home/Header";
 
 const FeedPage = () =>{
   return(
     <>
-      <MainHeader />
+      <CommonHeader />
       <Navbar/>
     </>
   )


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
to origin/Weekly_6
### 작업 내용 및 변경 사항
- 메인 페이지를 제외한 모든 페이지에 들어갈 공통헤더 추가 
- 메인페이지와는 상이하게 사이즈 조정(4vw => 3vw ; 3vw => 4vw) 
### 테스트 결과 이미지(화면 캡쳐해서)
<img width="2056" alt="スクリーンショット 0006-10-07 11 23 20" src="https://github.com/user-attachments/assets/ffaea7f7-eb76-47f8-aebe-f5b869132fb8">

### Todo

### 이슈 링크
#60 
### 리뷰어 멘션하기
@eunjin210 

### 기타
vw 아니고 vh로 바꿔야 할 것 같아용
지금은 가로로 줄이면 헤더 높이가 같이 줄어들어서 뭔가 안예쁨